### PR TITLE
fix: fix error in `process_total` using `Content-Range` when the DB response is not valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Add SERVER NAME and SCHEME config [#17](https://github.com/etalab/api-tabular/pull/17)
 - Override config with env [#18](https://github.com/etalab/api-tabular/pull/18)
 - Improve swagger and add new filters [#23](https://github.com/datagouv/api-tabular/pull/23)
+- Fix error in `process_total` using `Content-Range` when the DB response is not valid [#27](https://github.com/datagouv/api-tabular/pull/27)

--- a/api_tabular/utils.py
+++ b/api_tabular/utils.py
@@ -1,7 +1,6 @@
-from typing import Optional
-
 import yaml
 from aiohttp.web_request import Request
+from aiohttp.web_response import Response
 
 from api_tabular import config
 
@@ -63,12 +62,11 @@ def build_sql_query_string(request_arg: list, page_size: int = None, offset: int
     return "&".join(sql_query)
 
 
-def process_total(raw_total: Optional[str]) -> Optional[int]:
+def process_total(res: Response) -> int:
     # The raw total looks like this: '0-49/21777'
-    if raw_total:
-        _, str_total = raw_total.split("/")
-        return int(str_total)
-    return None
+    raw_total = res.headers.get("Content-Range")
+    _, str_total = raw_total.split("/")
+    return int(str_total)
 
 
 def external_url(url):

--- a/api_tabular/utils.py
+++ b/api_tabular/utils.py
@@ -63,7 +63,8 @@ def build_sql_query_string(request_arg: list, page_size: int = None, offset: int
 
 
 def process_total(res: Response) -> int:
-    # The raw total looks like this: '0-49/21777'
+    # the Content-Range looks like this: '0-49/21777'
+    # see https://docs.postgrest.org/en/stable/references/api/pagination_count.html
     raw_total = res.headers.get("Content-Range")
     _, str_total = raw_total.split("/")
     return int(str_total)

--- a/api_tabular/utils.py
+++ b/api_tabular/utils.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import yaml
 from aiohttp.web_request import Request
 
@@ -61,10 +63,12 @@ def build_sql_query_string(request_arg: list, page_size: int = None, offset: int
     return "&".join(sql_query)
 
 
-def process_total(raw_total: str) -> int:
+def process_total(raw_total: Optional[str]) -> Optional[int]:
     # The raw total looks like this: '0-49/21777'
-    _, str_total = raw_total.split("/")
-    return int(str_total)
+    if raw_total:
+        _, str_total = raw_total.split("/")
+        return int(str_total)
+    return None
 
 
 def external_url(url):


### PR DESCRIPTION
Attempt at fixing [Sentry error #146723](https://errors.data.gouv.fr/organizations/sentry/issues/146723/?project=23&referrer=project-issue-stream), which seems to be the most common Sentry error for TabularAPI.

Should we instead make sure `process_total` is never called when there is no `headers.get("Content-Range")`?