### PR TITLE
Add aggregators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Handle queries with aggregators [#35](https://github.com/datagouv/api-tabular/pull/35)
 
 ## 0.2.1 (2024-11-21)
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ curl http://localhost:8005/api/resources/aaaaaaaa-1111-bbbb-2222-cccccccccccc/da
 }
 ```
 
-This endpoint can be queried with the following operators as query string (replacing `column_name` with the name of an actual column):
+This endpoint can be queried with the following operators as query string (replacing `column_name` with the name of an actual column), if the column type allows it (see the swagger for each column's allowed parameter):
 
 ```
 # sort by column
@@ -142,7 +142,26 @@ column_name__strictly_less=value
 
 # strictly greater
 column_name__strictly_greater=value
+
+# group by values
+column_name__groupby
+
+# count values
+column_name__count
+
+# mean / average
+column_name__avg
+
+# minimum
+column_name__min
+
+# maximum
+column_name__max
+
+# sum
+column_name__sum
 ```
+> NB : passing an aggregation operator (`count`, `avg`, `min`, `max`, `sum`) returns a column that is named `<column_name>__<operator>` (for instance: `?birth__groupby&score__sum` will return a list of dicts with the keys `birth` and `score__sum`).
 
 For instance:
 ```shell
@@ -182,6 +201,31 @@ returns
     "page_size": 20,
     "total": 2
   }
+}
+```
+
+With filters and aggregators (filtering is always done **before** aggregation, no matter the order in the parameters):
+```shell
+curl http://localhost:8005/api/resources/aaaaaaaa-1111-bbbb-2222-cccccccccccc/data/?decompte__groupby&birth__less=1996&score__avg
+```
+i.e. `decompte` and average of `score` for all rows where `birth<="1996"`, grouped by `decompte`, returns
+```json
+{
+    "data": [
+        {
+            "decompte": 55,
+            "score__avg": 0.7123333333333334
+        },
+        {
+            "decompte": 27,
+            "score__avg": 0.6068888888888889
+        },
+        {
+            "decompte": 23,
+            "score__avg": 0.4603333333333334
+        },
+        ...
+    ]
 }
 ```
 

--- a/api_tabular/app.py
+++ b/api_tabular/app.py
@@ -96,8 +96,8 @@ async def resource_data(request):
 
     try:
         sql_query = build_sql_query_string(query_string, page_size, offset)
-    except ValueError:
-        raise QueryException(400, None, "Invalid query string", "Malformed query")
+    except ValueError as e:
+        raise QueryException(400, None, "Invalid query string", f"Malformed query: {e}")
 
     resource = await get_resource(request.app["csession"], resource_id, ["parsing_table"])
     response, total = await get_resource_data(request.app["csession"], resource, sql_query)

--- a/api_tabular/utils.py
+++ b/api_tabular/utils.py
@@ -13,7 +13,7 @@ TYPE_POSSIBILITIES = {
     "bool": ["differs", "exact", "in", "sort", "groupby", "count"],
     "date": ["compare", "contains", "differs", "exact", "in", "sort", "groupby", "count"],
     "datetime": ["compare", "contains", "differs", "exact", "in", "sort", "groupby", "count"],
-    "json": ["contains", "exact", "in", "groupby", "count"],
+    "json": ["contains", "differs", "exact", "in", "groupby", "count"],
 }
 
 MAP_TYPES = {
@@ -23,13 +23,47 @@ MAP_TYPES = {
     "float": "number",
 }
 
-MAP_OPERATORS = {
-    "groupby": "group by values",
-    "count": "count values",
-    "avg": "mean",
-    "min": "minimum",
-    "max": "maximum",
-    "sum": "sum",
+OPERATORS_DESCRIPTIONS = {
+    "exact": {
+        "name": "{}__exact=value",
+        "description": "Exact match in column: {}",
+    },
+    "differs": {
+        "name": "{}__differs=value",
+        "description": "Differs from in column: {}",
+    },
+    "contains": {
+        "name": "{}__contains=value",
+        "description": "String contains in column: {}",
+    },
+    "in": {
+        "name": "{}__in=value1,value2,...",
+        "description": "Value in list in column: {}",
+    },
+    "groupby": {
+        "name": "{}__groupby",
+        "description": "Performs `group by values` operation in column: {}",
+    },
+    "count": {
+        "name": "{}__count",
+        "description": "Performs `count values` operation in column: {}",
+    },
+    "avg": {
+        "name": "{}__avg",
+        "description": "Performs `mean` operation in column: {}",
+    },
+    "min": {
+        "name": "{}__min",
+        "description": "Performs `minimum` operation in column: {}",
+    },
+    "max": {
+        "name": "{}__max",
+        "description": "Performs `maximum` operation in column: {}",
+    },
+    "sum": {
+        "name": "{}__sum",
+        "description": "Performs `sum` operation in column: {}",
+    },
 }
 
 
@@ -176,42 +210,19 @@ def swagger_parameters(resource_columns):
     # see metier_to_python here: https://github.com/datagouv/csv-detective/blob/master/csv_detective/explore_csv.py
     # see cast for db here: https://github.com/datagouv/hydra/blob/main/udata_hydra/analysis/csv.py
     for key, value in resource_columns.items():
-        if "exact" in TYPE_POSSIBILITIES[value["python_type"]]:
-            parameters_list.extend(
-                [
-                    {
-                        "name": f"{key}__exact=value",
-                        "in": "query",
-                        "description": f"Exact match in column: {key}",
-                        "required": False,
-                        "schema": {"type": "string"},
-                    },
-                ]
-            )
-        if "differs" in TYPE_POSSIBILITIES[value["python_type"]]:
-            parameters_list.extend(
-                [
-                    {
-                        "name": f"{key}__differs=value",
-                        "in": "query",
-                        "description": f"Differs from in column: {key}",
-                        "required": False,
-                        "schema": {"type": "string"},
-                    },
-                ]
-            )
-        if "in" in TYPE_POSSIBILITIES[value["python_type"]]:
-            parameters_list.extend(
-                [
-                    {
-                        "name": f"{key}__in=value1,value2,...",
-                        "in": "query",
-                        "description": f"Value in list in column: {key}",
-                        "required": False,
-                        "schema": {"type": "string"},
-                    },
-                ]
-            )
+        for op in OPERATORS_DESCRIPTIONS:
+            if op in TYPE_POSSIBILITIES[value["python_type"]]:
+                parameters_list.extend(
+                    [
+                        {
+                            "name": OPERATORS_DESCRIPTIONS[op]["name"].format(key),
+                            "in": "query",
+                            "description": OPERATORS_DESCRIPTIONS[op]["description"].format(key),
+                            "required": False,
+                            "schema": {"type": "string"},
+                        },
+                    ]
+                )
         if "sort" in TYPE_POSSIBILITIES[value["python_type"]]:
             parameters_list.extend(
                 [
@@ -226,18 +237,6 @@ def swagger_parameters(resource_columns):
                         "name": f"{key}__sort=desc",
                         "in": "query",
                         "description": f"Sort descending on column: {key}",
-                        "required": False,
-                        "schema": {"type": "string"},
-                    },
-                ]
-            )
-        if "contains" in TYPE_POSSIBILITIES[value["python_type"]]:
-            parameters_list.extend(
-                [
-                    {
-                        "name": f"{key}__contains=value",
-                        "in": "query",
-                        "description": f"String contains in column: {key}",
                         "required": False,
                         "schema": {"type": "string"},
                     },
@@ -276,19 +275,6 @@ def swagger_parameters(resource_columns):
                     },
                 ]
             )
-        for op in MAP_OPERATORS:
-            if op in TYPE_POSSIBILITIES[value["python_type"]]:
-                parameters_list.extend(
-                    [
-                        {
-                            "name": f"{key}__{op}",
-                            "in": "query",
-                            "description": f"Performs `{MAP_OPERATORS[op]}` operation in column: {key}",
-                            "required": False,
-                            "schema": {"type": "string"},
-                        },
-                    ]
-                )
     return parameters_list
 
 

--- a/api_tabular/utils.py
+++ b/api_tabular/utils.py
@@ -123,7 +123,7 @@ def build_sql_query_string(request_arg: list, page_size: int = None, offset: int
             if column:
                 aggregators[operator].append(column)
         else:
-            raise ValueError
+            raise ValueError(f"argument '{arg}' could not be parsed")
     if aggregators:
         agg_query = "select="
         for operator in aggregators:
@@ -155,7 +155,7 @@ def get_column_and_operator(argument: str) -> tuple[str, str]:
     return column, normalized_comparator
 
 
-def add_filter(argument: str, value: str) -> tuple[Optional[str], bool]:
+def add_filter(argument: str, value: str) -> tuple[str, bool]:
     if "__" in argument:
         column, normalized_comparator = get_column_and_operator(argument)
         if normalized_comparator == "sort":
@@ -177,7 +177,7 @@ def add_filter(argument: str, value: str) -> tuple[Optional[str], bool]:
             return f"{column}=lt.{value}", False
         elif normalized_comparator == "strictly_greater":
             return f"{column}=gt.{value}", False
-    return None, False
+    raise ValueError(f"argument '{argument}' could not be parsed")
 
 
 def add_aggregator(argument: str) -> tuple[str, str]:
@@ -186,7 +186,7 @@ def add_aggregator(argument: str) -> tuple[str, str]:
         column, operator = get_column_and_operator(argument)
     if operator in ["avg", "count", "max", "min", "sum", "groupby"]:
         return column, operator
-    return None, None
+    raise ValueError(f"argument '{argument}' could not be parsed")
 
 
 def process_total(res: Response) -> int:

--- a/api_tabular/utils.py
+++ b/api_tabular/utils.py
@@ -48,10 +48,10 @@ def build_sql_query_string(request_arg: list, page_size: int = None, offset: int
             column = '"{}"'.format("__".join(column_split).replace('"', '\\"'))
 
             if normalized_comparator == "sort":
-                if value == "asc":
-                    sql_query.append(f"order={column}.asc,__id.asc")
-                elif value == "desc":
-                    sql_query.append(f"order={column}.desc,__id.asc")
+                q = f"order={column}.{value}"
+                if column != '"__id"':
+                    q += ',"__id".asc'
+                sql_query.append(q)
                 sorted = True
             elif normalized_comparator == "exact":
                 sql_query.append(f"{column}=eq.{value}")

--- a/api_tabular/utils.py
+++ b/api_tabular/utils.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+
 import tomllib
 import yaml
 from aiohttp.web_request import Request
@@ -8,8 +9,32 @@ from api_tabular import config
 
 TYPE_POSSIBILITIES = {
     "string": ["compare", "contains", "differs", "exact", "in", "sort", "groupby", "count"],
-    "float": ["compare", "differs", "exact", "in", "sort", "groupby", "count", "avg", "max", "min", "sum"],
-    "int": ["compare", "differs", "exact", "in", "sort", "groupby", "count", "avg", "max", "min", "sum"],
+    "float": [
+        "compare",
+        "differs",
+        "exact",
+        "in",
+        "sort",
+        "groupby",
+        "count",
+        "avg",
+        "max",
+        "min",
+        "sum",
+    ],
+    "int": [
+        "compare",
+        "differs",
+        "exact",
+        "in",
+        "sort",
+        "groupby",
+        "count",
+        "avg",
+        "max",
+        "min",
+        "sum",
+    ],
     "bool": ["differs", "exact", "in", "sort", "groupby", "count"],
     "date": ["compare", "contains", "differs", "exact", "in", "sort", "groupby", "count"],
     "datetime": ["compare", "contains", "differs", "exact", "in", "sort", "groupby", "count"],
@@ -135,7 +160,7 @@ def add_filter(argument: str, value: str) -> tuple[str, bool]:
         if normalized_comparator == "sort":
             q = f"order={column}.{value}"
             if column != '"__id"':
-                q += ',__id.asc'
+                q += ",__id.asc"
             return q, True
         elif normalized_comparator == "exact":
             return f"{column}=eq.{value}", False

--- a/api_tabular/utils.py
+++ b/api_tabular/utils.py
@@ -155,7 +155,9 @@ def get_column_and_operator(argument: str) -> tuple[str, str]:
     return column, normalized_comparator
 
 
-def add_filter(argument: str, value: str) -> tuple[str, bool]:
+def add_filter(argument: str, value: str) -> tuple[Optional[str], bool]:
+    if argument in ["page", "page_size"]:  # processed differently
+        return None, False
     if "__" in argument:
         column, normalized_comparator = get_column_and_operator(argument)
         if normalized_comparator == "sort":
@@ -177,7 +179,7 @@ def add_filter(argument: str, value: str) -> tuple[str, bool]:
             return f"{column}=lt.{value}", False
         elif normalized_comparator == "strictly_greater":
             return f"{column}=gt.{value}", False
-    raise ValueError(f"argument '{argument}' could not be parsed")
+    raise ValueError(f"argument '{argument}={value}' could not be parsed")
 
 
 def add_aggregator(argument: str) -> tuple[str, str]:

--- a/api_tabular/utils.py
+++ b/api_tabular/utils.py
@@ -160,8 +160,6 @@ def add_filter(argument: str, value: str) -> tuple[Optional[str], bool]:
         column, normalized_comparator = get_column_and_operator(argument)
         if normalized_comparator == "sort":
             q = f"order={column}.{value}"
-            if column != '"__id"':
-                q += ",__id.asc"
             return q, True
         elif normalized_comparator == "exact":
             return f"{column}=eq.{value}", False

--- a/api_tabular/utils.py
+++ b/api_tabular/utils.py
@@ -96,6 +96,8 @@ def build_sql_query_string(request_arg: list, page_size: int = None, offset: int
             column, operator = add_aggregator(_split[0])
             if column:
                 aggregators[operator].append(column)
+        else:
+            raise ValueError
     if aggregators:
         agg_query = "select="
         for operator in aggregators:
@@ -133,7 +135,7 @@ def add_filter(argument: str, value: str) -> tuple[str, bool]:
         if normalized_comparator == "sort":
             q = f"order={column}.{value}"
             if column != '"__id"':
-                q += ',"__id".asc'
+                q += ',__id.asc'
             return q, True
         elif normalized_comparator == "exact":
             return f"{column}=eq.{value}", False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgrest:
-    image: "postgrest/postgrest:v10.1.2"
+    image: "postgrest/postgrest:v12.2.3"
     environment:
       # connect to hydra database-csv
       - PGRST_DB_URI=postgres://csvapi:csvapi@postgres-test:5432/csvapi
@@ -10,6 +10,7 @@ services:
       - PGRST_SERVER_PORT=8080
       - PGRST_DB_ANON_ROLE=csvapi
       - PGRST_DB_SCHEMA=csvapi
+      - PGRST_DB_AGGREGATES_ENABLED=true
     ports:
       - 8080:8080
   postgres-test:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -137,8 +137,8 @@ async def test_api_resource_data_with_args_error(client, rmock):
         "errors": [
             {
                 "code": None,
-                "detail": "Malformed query",
                 "title": "Invalid query string",
+                "detail": "Malformed query: argument 'TESTCOLUM_NAME__EXACT=BIDULEpage=1' could not be parsed"
             }
         ]
     }
@@ -211,16 +211,15 @@ async def test_api_with_unsupported_args(client, rmock):
         headers={"Content-Range": "0-10/10"},
     )
     res = await client.get(f"/api/resources/{RESOURCE_ID}/data/?limit=1&select=numnum")
-    assert res.status == 200
+    assert res.status == 400
     body = {
-        "data": {"such": "data"},
-        "links": {
-            "next": None,
-            "prev": None,
-            "profile": external_url("/api/resources/aaaaaaaa-1111-bbbb-2222-cccccccccccc/profile/"),
-            "swagger": external_url("/api/resources/aaaaaaaa-1111-bbbb-2222-cccccccccccc/swagger/"),
-        },
-        "meta": {"page": 1, "page_size": 20, "total": 10},
+        "errors": [
+            {
+                "code": None,
+                "title": "Invalid query string",
+                "detail": "Malformed query: argument 'limit=1' could not be parsed"
+            },
+        ],
     }
     assert await res.json() == body
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -138,7 +138,7 @@ async def test_api_resource_data_with_args_error(client, rmock):
             {
                 "code": None,
                 "title": "Invalid query string",
-                "detail": "Malformed query: argument 'TESTCOLUM_NAME__EXACT=BIDULEpage=1' could not be parsed"
+                "detail": "Malformed query: argument 'TESTCOLUM_NAME__EXACT=BIDULEpage=1' could not be parsed",
             }
         ]
     }
@@ -217,7 +217,7 @@ async def test_api_with_unsupported_args(client, rmock):
             {
                 "code": None,
                 "title": "Invalid query string",
-                "detail": "Malformed query: argument 'limit=1' could not be parsed"
+                "detail": "Malformed query: argument 'limit=1' could not be parsed",
             },
         ],
     }

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -94,3 +94,22 @@ def test_query_build_multiple_with_unknown():
     query_str = ["select=numnum"]
     result = build_sql_query_string(query_str, 50)
     assert result == "limit=50&order=__id.asc"
+
+
+def test_query_aggregators():
+    query_str = [
+        "column_name__groupby",
+        "column_name__min",
+        "column_name__avg",
+    ]
+    results = build_sql_query_string(query_str, 50).split("&")
+    assert "limit=50" in results
+    assert "order=__id.asc" not in results  # no sort if aggregators
+    select = [_ for _ in results if "select" in _]
+    assert len(select) == 1
+    params = select[0].replace("select=", "").split(",")
+    assert all(_ in params for _ in [
+        '"column_name"',
+        '"column_name__min":"column_name".min()',
+        '"column_name__avg":"column_name".avg()',
+    ])

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -108,8 +108,11 @@ def test_query_aggregators():
     select = [_ for _ in results if "select" in _]
     assert len(select) == 1
     params = select[0].replace("select=", "").split(",")
-    assert all(_ in params for _ in [
-        '"column_name"',
-        '"column_name__min":"column_name".min()',
-        '"column_name__avg":"column_name".avg()',
-    ])
+    assert all(
+        _ in params
+        for _ in [
+            '"column_name"',
+            '"column_name__min":"column_name".min()',
+            '"column_name__avg":"column_name".avg()',
+        ]
+    )

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,3 +1,5 @@
+import pytest
+
 from api_tabular.utils import build_sql_query_string
 
 
@@ -16,13 +18,13 @@ def test_query_build_offset():
 def test_query_build_sort_asc():
     query_str = ["column_name__sort=asc"]
     result = build_sql_query_string(query_str, 50)
-    assert result == 'order="column_name".asc,__id.asc&limit=50'
+    assert result == 'order="column_name".asc&limit=50'
 
 
 def test_query_build_sort_asc_without_limit():
     query_str = ["column_name__sort=asc"]
     result = build_sql_query_string(query_str)
-    assert result == 'order="column_name".asc,__id.asc'
+    assert result == 'order="column_name".asc'
 
 
 def test_query_build_sort_asc_with_page_in_query():
@@ -32,13 +34,13 @@ def test_query_build_sort_asc_with_page_in_query():
         "page_size=20",
     ]
     result = build_sql_query_string(query_str)
-    assert result == 'order="column_name".asc,__id.asc'
+    assert result == 'order="column_name".asc'
 
 
 def test_query_build_sort_desc():
     query_str = ["column_name__sort=desc"]
     result = build_sql_query_string(query_str, 50)
-    assert result == 'order="column_name".desc,__id.asc&limit=50'
+    assert result == 'order="column_name".desc&limit=50'
 
 
 def test_query_build_exact():
@@ -92,8 +94,8 @@ def test_query_build_multiple():
 
 def test_query_build_multiple_with_unknown():
     query_str = ["select=numnum"]
-    result = build_sql_query_string(query_str, 50)
-    assert result == "limit=50&order=__id.asc"
+    with pytest.raises(ValueError):
+        build_sql_query_string(query_str, 50)
 
 
 def test_query_aggregators():

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -49,5 +49,8 @@ async def test_swagger_content(client, rmock):
                 elif p == "in":
                     value = "value1,value2,..."
                 for _p in _params:
-                    if f"{c}__{_p}={value}" not in params:
+                    if (
+                        f"{c}__{_p}={value}" not in params  # filters
+                        and f"{c}__{_p}" not in params  # aggregators
+                    ):
                         raise ValueError(f"{c}__{_p} is missing in {output} output")


### PR DESCRIPTION
Side note: I am wondering whether we want to change the behaviour for malformed queries like in [this test](https://github.com/datagouv/api-tabular/blob/f5afe16a47992956fe86ab01ea31e34fcd076e35/tests/test_query.py#L93). Do we want this kind of query to complete and return stuff, or would we rather have it crash explicitly?
Update: answer "yes"

PS: this PR will be followed by one that introduces auth for requests involving aggregators