### PR TITLE
Add postgrest version in health checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add PostgREST version in health endpoint [#37](https://github.com/datagouv/api-tabular/pull/37)
 
 ## 0.2.2 (2024-11-28)
 

--- a/api_tabular/app.py
+++ b/api_tabular/app.py
@@ -19,6 +19,7 @@ from api_tabular.utils import (
     build_sql_query_string,
     build_swagger_file,
     get_app_version,
+    get_postgrest_version,
     url_for,
 )
 
@@ -153,7 +154,12 @@ async def get_health(request):
     current_time = datetime.now(timezone.utc)
     uptime_seconds = (current_time - start_time).total_seconds()
     return web.json_response(
-        {"status": "ok", "version": request.app["app_version"], "uptime_seconds": uptime_seconds}
+        {
+            "status": "ok",
+            "version": request.app["app_version"],
+            "postgrest_version": await get_postgrest_version(),
+            "uptime_seconds": uptime_seconds,
+        },
     )
 
 

--- a/api_tabular/utils.py
+++ b/api_tabular/utils.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import tomllib
 import yaml
+from aiohttp import ClientSession
 from aiohttp.web_request import Request
 from aiohttp.web_response import Response
 
@@ -101,6 +102,13 @@ OPERATORS_DESCRIPTIONS = {
 
 def is_aggregation_allowed(resource_id: str):
     return resource_id in config.ALLOW_AGGREGATION
+
+
+async def get_postgrest_version() -> str:
+    session = ClientSession()
+    async with session.get(config.PGREST_ENDPOINT) as res:
+        content = await res.json()
+    return content["info"]["version"]
 
 
 async def get_app_version() -> str:


### PR DESCRIPTION
`/health/` now looks like:
```
{
    "status": "ok",
    "version": "0.2.3.dev",
    "postgrest_version": "12.2.3",
    "uptime_seconds": 0.692561
}
```