### PR TITLE
Cast env configs as expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Add PostgREST version in health endpoint [#37](https://github.com/datagouv/api-tabular/pull/37)
+- Cast env configs as expected [#39](https://github.com/datagouv/api-tabular/pull/39)
 
 ## 0.2.2 (2024-11-28)
 

--- a/api_tabular/__init__.py
+++ b/api_tabular/__init__.py
@@ -27,7 +27,17 @@ class Configurator:
         # override with os env settings
         for config_key in configuration:
             if config_key in os.environ:
-                configuration[config_key] = os.getenv(config_key)
+                value = os.getenv(config_key)
+                # Casting env value
+                if isinstance(configuration[config_key], list):
+                    value = value.split(",")
+                elif isinstance(configuration[config_key], bool):
+                    value = value.lower() in ["true", "1", "t", "y", "yes"]
+                elif isinstance(configuration[config_key], int):
+                    value = int(value)
+                elif isinstance(configuration[config_key], float):
+                    value = float(value)
+                configuration[config_key] = value
 
         # Make sure PGREST_ENDPOINT has a scheme
         if not configuration["PGREST_ENDPOINT"].startswith("http"):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,46 @@
+import os
+import unittest.mock as mock
+from pathlib import Path
+
+import tomllib
+
+from api_tabular import Configurator
+
+builtin_open = open
+
+
+# Mock custom config.toml with specific PAGE_SIZE_MAX value
+def mock_open_with_custom_config_toml(*args, **kwargs):
+    if args[0].name == "config.toml":
+        # mocked open for path "config.toml"
+        return mock.mock_open(read_data=b"PAGE_SIZE_MAX = 200")(*args, **kwargs)
+    # unpatched version for every other path
+    return builtin_open(*args, **kwargs)
+
+
+def test_default_config():
+    config = Configurator()
+
+    assert config.PAGE_SIZE_MAX == 50
+
+    # Make sure all config keys are defined
+    with open(Path(__file__).parent.parent / "api_tabular/config_default.toml", "rb") as f:
+        assert config.configuration.keys() == tomllib.load(f).keys()
+
+
+@mock.patch("builtins.open", mock_open_with_custom_config_toml)
+def test_custom_config_file_override():
+    config = Configurator()
+
+    assert config.PAGE_SIZE_MAX == 200
+
+
+def test_env_override():
+    os.environ["PGREST_ENDPOINT"] = "https://example.com"
+    os.environ["PAGE_SIZE_MAX"] = "200"
+    os.environ["ALLOW_AGGREGATION"] = "a,b,c"
+    config = Configurator()
+
+    assert config.PGREST_ENDPOINT == "https://example.com"
+    assert config.PAGE_SIZE_MAX == 200
+    assert config.ALLOW_AGGREGATION == ["a", "b", "c"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,7 +30,9 @@ def test_default_config():
 
 @mock.patch("builtins.open", mock_open_with_custom_config_toml)
 def test_custom_config_file_override():
-    config = Configurator()
+    with mock.patch.object(Path, "exists") as mock_exists:
+        mock_exists.return_value = True
+        config = Configurator()
 
     assert config.PAGE_SIZE_MAX == 200
 

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -43,7 +43,7 @@ async def test_swagger_content(client, rmock, allow_aggregation, mocker):
 
     for output in ["json", "csv"]:
         params = swagger_dict["paths"][
-            f'/api/resources/{RESOURCE_ID}/data/{"" if output == "json" else "csv/"}'
+            f"/api/resources/{RESOURCE_ID}/data/{'' if output == 'json' else 'csv/'}"
         ]["parameters"]
         params = [p["name"] for p in params]
         for c in columns:


### PR DESCRIPTION
If we don't cast, using environment variable to set `PAGE_SIZE_MAX=200` would lead to it being treated as string.