### PR TITLE
Revert "Add postgrest version in health checkpoint (#37)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Remove PostgREST version in health endpoint [#43](https://github.com/datagouv/api-tabular/pull/43)
 
 ## 0.2.4 (2025-03-20)
 

--- a/api_tabular/app.py
+++ b/api_tabular/app.py
@@ -19,7 +19,6 @@ from api_tabular.utils import (
     build_sql_query_string,
     build_swagger_file,
     get_app_version,
-    get_postgrest_version,
     url_for,
 )
 
@@ -174,12 +173,7 @@ async def get_health(request):
     current_time = datetime.now(timezone.utc)
     uptime_seconds = (current_time - start_time).total_seconds()
     return web.json_response(
-        {
-            "status": "ok",
-            "version": request.app["app_version"],
-            "postgrest_version": await get_postgrest_version(),
-            "uptime_seconds": uptime_seconds,
-        },
+        {"status": "ok", "version": request.app["app_version"], "uptime_seconds": uptime_seconds}
     )
 
 

--- a/api_tabular/utils.py
+++ b/api_tabular/utils.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 
 import tomllib
 import yaml
-from aiohttp import ClientSession
 from aiohttp.web_request import Request
 from aiohttp.web_response import Response
 
@@ -101,13 +100,6 @@ OPERATORS_DESCRIPTIONS = {
 
 def is_aggregation_allowed(resource_id: str):
     return resource_id in config.ALLOW_AGGREGATION
-
-
-async def get_postgrest_version() -> str:
-    session = ClientSession()
-    async with session.get(config.PGREST_ENDPOINT) as res:
-        content = await res.json()
-    return content["info"]["version"]
 
 
 async def get_app_version() -> str:


### PR DESCRIPTION
This reverts commit e189dc9e7f6abc36aec4e9da8c9aeaed2b1ede99.

Indeed, requesting `config.PGREST_ENDPOINT` root endpoint returns the entire description of all tables served by PostgREST.
It is not scalable.