### PR TITLE
ci: simplify CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,42 +19,16 @@ parameters:
     default: "8005"
 
 jobs:
-  install:
+  lint:
     docker:
       - image: acidrain/python-poetry:<< pipeline.parameters.python-version >>-alpine
     steps:
       - checkout
       - run:
-          name: Show Poetry version
-          command: poetry --version
-      - run:
-          name: Get the base reference branch
-          command: export BASE_BRANCH=$(base_branch)
-      - restore_cache:
-          keys:
-            - << pipeline.parameters.cache-prefix >>-v1-{{ arch }}-{{ checksum "poetry.lock" }}
-            - << pipeline.parameters.cache-prefix >>-v1-{{ arch }}-{{ .Branch }}
-            - << pipeline.parameters.cache-prefix >>-v1-{{ arch }}-{{ .Environment.BASE_BRANCH }}
-      - run:
-          name: Install Python dependencies with Poetry
+          name: Install Python dev dependencies only with Poetry
           command: |
             poetry config virtualenvs.in-project true
             poetry install --no-root --extras "dev"
-      - save_cache:
-          key: << pipeline.parameters.cache-prefix >>-v1-{{ arch }}-{{ checksum "poetry.lock" }}
-          paths:
-            - .venv
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
-
-  lint:
-    docker:
-      - image: acidrain/python-poetry:<< pipeline.parameters.python-version >>-alpine
-    steps:
-      - attach_workspace:
-          at: .
       - run:
           name: Lint and format code and sort imports
           # ruff check --select I . : check linting and imports sorting without fixing (to fix, use --fix)
@@ -107,8 +81,12 @@ jobs:
     docker:
       - image: acidrain/python-poetry:<< pipeline.parameters.python-version >>-alpine
     steps:
-      - attach_workspace:
-          at: .
+      - checkout
+      - run:
+          name: Install Python dependencies with Poetry
+          command: |
+            poetry config virtualenvs.in-project true
+            poetry install --no-root
       - run:
           name: Set the version number
           command: |
@@ -160,13 +138,7 @@ jobs:
 workflows:
   build-test-deploy:
     jobs:
-      - install:
-          filters:
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*/
       - lint:
-          requires:
-            - install
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/


### PR DESCRIPTION
# Simplify CI Configuration

## Summary

This PR simplifies the CI pipeline by removing the separate install job and having each job install its own dependencies directly.

## Why This Change

The previous approach of caching the install step provided minimal benefits since Poetry 2 installs dependencies in just a few seconds (2s. to 4s. - see CI screenshots). The complexity of managing a separate install job with workspace persistence wasn't worth the negligible performance gain, and it might be even faster since we don't have to spin off the job "install" in the CI anymore (see CI screenshots).



## Benefits

- **Easier maintenance, simpler**: Less complex YAML configuration, each job is self-contained and easier to understand, no dependency on workspace persistence between jobs
- **Faster**: might be even faster since we don't have to spin off the job "install" in the CI anymore

## Changes

- Removed install job and workspace persistence
- Each job now runs `poetry install` with appropriate flags
- Lint job: `--extras "dev"` (dev dependencies only)
- Build job: `--no-root` (main dependencies only)
- Tests job: `--extras "dev"` (dev dependencies)

<img width="926" height="76" alt="screenshot 2025-07-15 at 14 32 25" src="https://github.com/user-attachments/assets/b23c6df8-8df5-4cae-8b43-ff2f8506f9d9" />
<img width="906" height="70" alt="screenshot 2025-07-15 at 14 32 35" src="https://github.com/user-attachments/assets/56d8c0e7-dd8c-4f8d-91d8-5f0ae3e07363" />
<img width="935" height="254" alt="screenshot 2025-07-15 at 14 32 40" src="https://github.com/user-attachments/assets/2d59b99c-9b93-4930-9960-25b968b1ce3a" />