### PR TITLE
Fix swagger structure according to guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Return HTTP 410 Gone response for deleted resources [#56](https://github.com/datagouv/api-tabular/pull/56)
 - Fix CI due to end-of-lifed ubuntu distro [#62](https://github.com/datagouv/api-tabular/pull/62)
+- Fix swagger structure according to guidelines [#60](https://github.com/datagouv/api-tabular/pull/60)
 
 ## 0.2.5 (2025-07-21)
 

--- a/api_tabular/utils.py
+++ b/api_tabular/utils.py
@@ -64,6 +64,7 @@ OPERATORS_DESCRIPTIONS = {
     "in": {
         "name": "{}__in",
         "description": "Value in list in column: {} ({}__in=value1,value2,...)",
+        "example": "value1,value2,value3"
     },
     "groupby": {
         "name": "{}__groupby",
@@ -259,6 +260,7 @@ def swagger_parameters(resource_columns: dict, resource_id: str) -> list:
             "description": "Specific page (page=value)",
             "required": False,
             "schema": {"type": "integer"},
+            "example": 1,
         },
         {
             "name": "page_size",
@@ -266,6 +268,7 @@ def swagger_parameters(resource_columns: dict, resource_id: str) -> list:
             "description": "Number of results per page (page_size=value)",
             "required": False,
             "schema": {"type": "integer"},
+            "example": 1,
         },
         {
             "name": "columns",
@@ -275,7 +278,8 @@ def swagger_parameters(resource_columns: dict, resource_id: str) -> list:
             "schema": {"type": "string"},
             # see https://swagger.io/docs/specification/v3_0/serialization/
             "style": "form",
-            "explode": "false",
+            "explode": False,
+            "example": "column1,column2,column4",
         },
     ]
     # expected python types are: string, float, int, bool, date, datetime, json
@@ -307,7 +311,7 @@ def swagger_parameters(resource_columns: dict, resource_id: str) -> list:
                                 "allowEmptyValue": True,
                             }
                             if OPERATORS_DESCRIPTIONS[op].get("is_aggregator")
-                            else {}
+                            else {"example": OPERATORS_DESCRIPTIONS[op].get("example", "value")}
                         ),
                     ]
                 )
@@ -323,6 +327,7 @@ def swagger_parameters(resource_columns: dict, resource_id: str) -> list:
                         ),
                         "required": False,
                         "schema": {"type": "string"},
+                        "example": "asc",
                     },
                 ]
             )
@@ -335,6 +340,7 @@ def swagger_parameters(resource_columns: dict, resource_id: str) -> list:
                         "description": f"Less than in column: {key} ({key}__less=value)",
                         "required": False,
                         "schema": {"type": "string"},
+                        "example": "value",
                     },
                     {
                         "name": f"{key}__greater",
@@ -342,6 +348,7 @@ def swagger_parameters(resource_columns: dict, resource_id: str) -> list:
                         "description": f"Greater than in column: {key} ({key}__greater=value)",
                         "required": False,
                         "schema": {"type": "string"},
+                        "example": "value",
                     },
                     {
                         "name": f"{key}__strictly_less",
@@ -349,6 +356,7 @@ def swagger_parameters(resource_columns: dict, resource_id: str) -> list:
                         "description": f"Strictly less than in column: {key} ({key}__strictly_less=value)",
                         "required": False,
                         "schema": {"type": "string"},
+                        "example": "value",
                     },
                     {
                         "name": f"{key}__strictly_greater",
@@ -356,6 +364,7 @@ def swagger_parameters(resource_columns: dict, resource_id: str) -> list:
                         "description": f"Strictly greater than in column: {key} ({key}__strictly_greater=value)",
                         "required": False,
                         "schema": {"type": "string"},
+                        "example": "value",
                     },
                 ]
             )

--- a/api_tabular/utils.py
+++ b/api_tabular/utils.py
@@ -64,7 +64,7 @@ OPERATORS_DESCRIPTIONS = {
     "in": {
         "name": "{}__in",
         "description": "Value in list in column: {} ({}__in=value1,value2,...)",
-        "example": "value1,value2,value3"
+        "example": "value1,value2,value3",
     },
     "groupby": {
         "name": "{}__groupby",

--- a/api_tabular/utils.py
+++ b/api_tabular/utils.py
@@ -299,7 +299,8 @@ def swagger_parameters(resource_columns: dict, resource_id: str) -> list:
                             ),
                             "required": False,
                             "schema": {"type": "string"},
-                        } | (
+                        }
+                        | (
                             # aggregators don't need a value
                             {
                                 "schema": {"type": "boolean", "default": False},

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -69,6 +69,7 @@ async def test_swagger_no_indexes(client, base_url, tables_index_rows, params):
                             and f"{c}__{_p}" not in params  # filters are in
                         ):
                             missing.append(f"{c}__{_p} is missing in {output} output")
+                            assert params[f"{c}__{_p}"].get("allowEmptyValue") is None
                         if (
                             OPERATORS_DESCRIPTIONS.get(_p, {}).get("is_aggregator")
                             and f"{c}__{_p}" in params  # aggregators are out

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -49,7 +49,7 @@ async def test_swagger_no_indexes(client, base_url, tables_index_rows, params):
         params = swagger_dict["paths"][
             f"/api/resources/{_resource_id}/data/{'' if output == 'json' else 'csv/'}"
         ]["parameters"]
-        params = [p["name"] for p in params]
+        params = {p["name"]: p for p in params}
         for c in columns:
             for p in TYPE_POSSIBILITIES[columns[c]]:
                 _params = (
@@ -57,22 +57,16 @@ async def test_swagger_no_indexes(client, base_url, tables_index_rows, params):
                     if p == "compare"
                     else [p]
                 )
-                value = "value"
-                if p == "sort":
-                    value = "asc"
-                elif p == "in":
-                    value = "value1,value2,..."
                 for _p in _params:
                     if allow_aggregation:
-                        if (
-                            f"{c}__{_p}={value}" not in params  # filters
-                            and f"{c}__{_p}" not in params  # aggregators
-                        ):
+                        if f"{c}__{_p}" not in params:
                             missing.append(f"{c}__{_p} is missing in {output} output")
+                        elif OPERATORS_DESCRIPTIONS.get(_p, {}).get("is_aggregator"):
+                            assert params[f"{c}__{_p}"].get("allowEmptyValue")
                     else:
                         if (
                             not OPERATORS_DESCRIPTIONS.get(_p, {}).get("is_aggregator")
-                            and f"{c}__{_p}={value}" not in params  # filters are in
+                            and f"{c}__{_p}" not in params  # filters are in
                         ):
                             missing.append(f"{c}__{_p} is missing in {output} output")
                         if (


### PR DESCRIPTION
Currently the swagger doesn't work in the Swagger tab of the resources (due to the `=value` in the name). This PR reshapes it to better fit [the OpenAPI guidelines](https://swagger.io/docs/specification/v3_0/describing-parameters/#query-parameters)