### PR TITLE
docs: fix python versions constraints inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The production API is deployed on data.gouv.fr infrastructure at [`https://tabul
 
 ### 📋 Requirements
 
-- **Python** >= 3.11, < 3.13
+- **Python** >= 3.11, < 3.14
 - **[uv](https://docs.astral.sh/uv/)** for dependency management
 - **Docker & Docker Compose**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "aiohttp-swagger==1.0.16",
     "sentry-sdk<3.0.0,>=2.13.0",
 ]
-requires-python = "<4.0,>=3.11"
+requires-python = "<3.14,>=3.11"
 license = "MIT"
 readme = "README.md"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.11, <4.0"
+requires-python = ">=3.11, <3.14"
 
 [[package]]
 name = "aiohappyeyeballs"


### PR DESCRIPTION
Fix Python versions contraints inconsistencies in `pyproject.toml` and README.md, and rebuild the lock file to take the versions constraints into account.

It was tested with Python 3.14 and does NOT work (yet) with 3.14, because of the subdependency `watchfile` of `aiohttp-devtools` being incompatible.