### PR TITLE
chore: move pyproject optional-dependencies to dependency-groups

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,8 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install dependencies and dev dependencies
-          command: uv sync --frozen --extra dev
+          name: Install Python dependencies
+          command: uv sync --frozen
       - run:
           name: Lint and format code and sort imports
           # ruff check --select I . : check linting and imports sorting without fixing (to fix, use --fix)
@@ -57,7 +57,7 @@ jobs:
             curl -LsSf https://astral.sh/uv/install.sh | sh
             export PATH="$HOME/.local/bin:$PATH"
             uv python install << pipeline.parameters.python-version >>
-            uv sync --frozen --extra dev
+            uv sync --frozen
       - run:
           name: Start service
           command: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requires-python = "<3.14,>=3.11"
 license = "MIT"
 readme = "README.md"
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "aiohttp-devtools<2.0.0,>=1.0.post0",
     "aioresponses<1.0.0,>=0.7.4",

--- a/uv.lock
+++ b/uv.lock
@@ -544,7 +544,7 @@ dependencies = [
     { name = "sentry-sdk" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "aiohttp-devtools" },
     { name = "aioresponses" },
@@ -558,16 +558,19 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.8.4,<4.0.0" },
     { name = "aiohttp-cors", specifier = "==0.7.0" },
-    { name = "aiohttp-devtools", marker = "extra == 'dev'", specifier = ">=1.0.post0,<2.0.0" },
     { name = "aiohttp-swagger", specifier = "==1.0.16" },
-    { name = "aioresponses", marker = "extra == 'dev'", specifier = ">=0.7.4,<1.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.2.1,<8.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.20.3,<1.0.0" },
-    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.10.0,<4.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.5,<1.0.0" },
     { name = "sentry-sdk", specifier = ">=2.13.0,<3.0.0" },
 ]
-provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "aiohttp-devtools", specifier = ">=1.0.post0,<2.0.0" },
+    { name = "aioresponses", specifier = ">=0.7.4,<1.0.0" },
+    { name = "pytest", specifier = ">=7.2.1,<8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.20.3,<1.0.0" },
+    { name = "pytest-mock", specifier = ">=3.10.0,<4.0.0" },
+    { name = "ruff", specifier = ">=0.6.5,<1.0.0" },
+]
 
 [[package]]
 name = "urllib3"


### PR DESCRIPTION
See https://github.com/opendatateam/udata/pull/3560, as spotted by @streino , use a more standard group for dev dependencies in pyproject.toml