### PR TITLE
ci: build Docker image and push to registry from applicative's CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,12 @@ parameters:
   api-port:
     type: string
     default: "8005"
+  docker-registry-url:
+    type: string
+    default: "registry.gitlab.com/etalab/data.gouv.fr/infra"
+  docker-image-name:
+    type: string
+    default: "tabular-api"
 
 jobs:
   lint:
@@ -70,13 +76,21 @@ jobs:
           path: reports/python
 
   build:
-    docker:
-      - image: ghcr.io/astral-sh/uv:python<< pipeline.parameters.python-version >>-trixie
+    machine:
+      image: ubuntu-2404:current
     steps:
       - checkout
       - run:
-          name: Compute RELEASE_VERSION via setuptools_scm
+          name: Install uv and Python << pipeline.parameters.python-version >>
           command: |
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            export PATH="$HOME/.local/bin:$PATH"
+            uv python install << pipeline.parameters.python-version >>
+            uv sync --frozen
+      - run:
+          name: Compute RELEASE_VERSION via setuptools_scm and build wheel
+          command: |
+            export PATH="$HOME/.local/bin:$PATH"
             uv pip install --system setuptools-scm
             # derive from setuptools_scm or base version + build number
             RELEASE_VERSION=$(python -m setuptools_scm)
@@ -84,19 +98,38 @@ jobs:
             echo "Build number: $CIRCLE_BUILD_NUM"
             echo "Commit hash: ${CIRCLE_SHA1:0:7}"
             echo "Git tag: $CIRCLE_TAG"
-      - run:
-          name: Build a distributable package as a wheel release
-          command: |
             uv build --wheel
-      # Build already executed above; artifacts are in dist/
       - store_artifacts:
           path: dist
       - persist_to_workspace:
           root: .
           paths:
             - .
+      - run:
+          name: Set Docker image tag
+          command: |
+            if [ -n "$CIRCLE_TAG" ]; then
+              export DOCKER_IMAGE_TAG="$CIRCLE_TAG"
+            elif [ -n "$CIRCLE_BRANCH" ]; then
+              export DOCKER_IMAGE_TAG="$CIRCLE_BRANCH"
+            else
+              export DOCKER_IMAGE_TAG="${CIRCLE_SHA1:0:7}"
+            fi
+            echo "DOCKER_IMAGE_TAG=$DOCKER_IMAGE_TAG" >> "$BASH_ENV"
+      - run:
+          name: Log in to Docker registry
+          command: |
+            echo "${DOCKER_REGISTRY_PASSWORD}" | docker login -u "${DOCKER_REGISTRY_USER}" --password-stdin registry.gitlab.com
+      - run:
+          name: Build and push Docker image
+          command: |
+            source "$BASH_ENV"
+            export PATH="$HOME/.local/bin:$PATH"
+            IMAGE="<< pipeline.parameters.docker-registry-url >>/<< pipeline.parameters.docker-image-name >>:${DOCKER_IMAGE_TAG}"
+            docker build -t "$IMAGE" .
+            docker push "$IMAGE"
 
-  publish:
+  publish-pypi:
     docker:
       - image: ghcr.io/astral-sh/uv:python<< pipeline.parameters.python-version >>-trixie-slim
     steps:
@@ -116,7 +149,7 @@ workflows:
           requires:
             - lint
             - tests
-      - publish:
+      - publish-pypi:
           requires:
             - build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - run:
           name: Log in to Docker registry
           command: |
-            echo "${DOCKER_REGISTRY_PASSWORD}" | docker login -u "${DOCKER_REGISTRY_USER}" --password-stdin registry.gitlab.com
+            echo "${DOCKER_REGISTRY_PASSWORD}" | docker login -u "oauth2" --password-stdin registry.gitlab.com
       - run:
           name: Build and push Docker images (Tabular API and Metrics API)
           command: |
@@ -151,6 +151,7 @@ workflows:
           filters:
             branches:
               only: << pipeline.parameters.publish-branch >>
+          context: org-global
       - publish-pypi:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,9 @@ workflows:
           requires:
             - lint
             - tests
+          filters:
+            branches:
+              only: << pipeline.parameters.publish-branch >>
       - publish-pypi:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,12 @@ parameters:
   docker-registry-url:
     type: string
     default: "registry.gitlab.com/etalab/data.gouv.fr/infra"
-  docker-image-name:
+  docker-image-name-tabular:
     type: string
     default: "tabular-api"
+  docker-image-name-metrics:
+    type: string
+    default: "metrics-api"
 
 jobs:
   lint:
@@ -111,15 +114,19 @@ jobs:
           command: |
             echo "${DOCKER_REGISTRY_PASSWORD}" | docker login -u "${DOCKER_REGISTRY_USER}" --password-stdin registry.gitlab.com
       - run:
-          name: Build and push Docker image
+          name: Build and push Docker images (Tabular API and Metrics API)
           command: |
             source "$BASH_ENV"
             export PATH="$HOME/.local/bin:$PATH"
+            REGISTRY="<< pipeline.parameters.docker-registry-url >>"
             # Docker tags allow only [a-zA-Z0-9_.-]; setuptools_scm can output e.g. 0.4.0.dev5+gabc1234
             DOCKER_TAG=$(echo "$RELEASE_VERSION" | tr '+' '-')
-            IMAGE="<< pipeline.parameters.docker-registry-url >>/<< pipeline.parameters.docker-image-name >>:${DOCKER_TAG}"
-            docker build -t "$IMAGE" .
-            docker push "$IMAGE"
+            # Tabular API: tabular endpoints only
+            docker build --build-arg APP_MODULE=api_tabular.tabular.app:app_factory -t "${REGISTRY}/<< pipeline.parameters.docker-image-name-tabular >>:${DOCKER_TAG}" .
+            docker push "${REGISTRY}/<< pipeline.parameters.docker-image-name-tabular >>:${DOCKER_TAG}"
+            # Metrics API: metrics endpoints only
+            docker build --build-arg APP_MODULE=api_tabular.metrics.app:app_factory -t "${REGISTRY}/<< pipeline.parameters.docker-image-name-metrics >>:${DOCKER_TAG}" .
+            docker push "${REGISTRY}/<< pipeline.parameters.docker-image-name-metrics >>:${DOCKER_TAG}"
 
   publish-pypi:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
             uv python install << pipeline.parameters.python-version >>
             uv sync --frozen
       - run:
-          name: Compute RELEASE_VERSION via setuptools_scm and build wheel
+          name: Compute RELEASE_VERSION via setuptools_scm, and build wheel
           command: |
             export PATH="$HOME/.local/bin:$PATH"
             uv pip install --system setuptools-scm
@@ -98,6 +98,7 @@ jobs:
             echo "Build number: $CIRCLE_BUILD_NUM"
             echo "Commit hash: ${CIRCLE_SHA1:0:7}"
             echo "Git tag: $CIRCLE_TAG"
+            echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$BASH_ENV"
             uv build --wheel
       - store_artifacts:
           path: dist
@@ -105,17 +106,6 @@ jobs:
           root: .
           paths:
             - .
-      - run:
-          name: Set Docker image tag
-          command: |
-            if [ -n "$CIRCLE_TAG" ]; then
-              export DOCKER_IMAGE_TAG="$CIRCLE_TAG"
-            elif [ -n "$CIRCLE_BRANCH" ]; then
-              export DOCKER_IMAGE_TAG="$CIRCLE_BRANCH"
-            else
-              export DOCKER_IMAGE_TAG="${CIRCLE_SHA1:0:7}"
-            fi
-            echo "DOCKER_IMAGE_TAG=$DOCKER_IMAGE_TAG" >> "$BASH_ENV"
       - run:
           name: Log in to Docker registry
           command: |
@@ -125,7 +115,9 @@ jobs:
           command: |
             source "$BASH_ENV"
             export PATH="$HOME/.local/bin:$PATH"
-            IMAGE="<< pipeline.parameters.docker-registry-url >>/<< pipeline.parameters.docker-image-name >>:${DOCKER_IMAGE_TAG}"
+            # Docker tags allow only [a-zA-Z0-9_.-]; setuptools_scm can output e.g. 0.4.0.dev5+gabc1234
+            DOCKER_TAG=$(echo "$RELEASE_VERSION" | tr '+' '-')
+            IMAGE="<< pipeline.parameters.docker-registry-url >>/<< pipeline.parameters.docker-image-name >>:${DOCKER_TAG}"
             docker build -t "$IMAGE" .
             docker push "$IMAGE"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,12 @@ parameters:
   publish-branch:
     type: string
     default: "main"
+  python-module:
+    type: string
+    default: "api_tabular"
+  api-port:
+    type: string
+    default: "8005"
 
 jobs:
   lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,21 +8,15 @@ parameters:
   publish-branch:
     type: string
     default: "main"
-  python-module:
+  docker-registry-host:
     type: string
-    default: "api_tabular"
-  api-port:
+    default: "registry.gitlab.com"
+  docker-repo-tabular:
     type: string
-    default: "8005"
-  docker-registry-url:
+    default: "registry.gitlab.com/etalab/data.gouv.fr/infra/tabular-api"
+  docker-repo-metrics:
     type: string
-    default: "registry.gitlab.com/etalab/data.gouv.fr/infra"
-  docker-image-name-tabular:
-    type: string
-    default: "tabular-api"
-  docker-image-name-metrics:
-    type: string
-    default: "metrics-api"
+    default: "registry.gitlab.com/etalab/data.gouv.fr/infra/metrics-api"
 
 jobs:
   lint:
@@ -108,25 +102,50 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - .
+            - dist
+            - pyproject.toml
       - run:
           name: Log in to Docker registry
           command: |
-            echo "${DOCKER_REGISTRY_PASSWORD}" | docker login -u "oauth2" --password-stdin registry.gitlab.com
+            echo "${DOCKER_REGISTRY_PASSWORD}" | docker login -u "oauth2" --password-stdin << pipeline.parameters.docker-registry-host >>
       - run:
           name: Build and push Docker images (Tabular API and Metrics API)
           command: |
             source "$BASH_ENV"
             export PATH="$HOME/.local/bin:$PATH"
-            REGISTRY="<< pipeline.parameters.docker-registry-url >>"
+            # Five distinct tags per image (SCM version, SHA short/long, branch, optional git tag).
             # Docker tags allow only [a-zA-Z0-9_.-]; setuptools_scm can output e.g. 0.4.0.dev5+gabc1234
-            DOCKER_TAG=$(echo "$RELEASE_VERSION" | tr '+' '-')
+            DOCKER_TAG_SCM=$(echo "$RELEASE_VERSION" | tr '+' '-')
+            DOCKER_TAG_SHA_SHORT="${CIRCLE_SHA1:0:7}"
+            DOCKER_TAG_SHA_LONG="$CIRCLE_SHA1"
+            DOCKER_TAG_BRANCH=$(printf '%s' "$CIRCLE_BRANCH" | tr '/' '-' | sed 's/[^a-zA-Z0-9_.-]/-/g')
+            DOCKER_TAG_GIT="${CIRCLE_TAG:-}"
             # Tabular API: tabular endpoints only
-            docker build --build-arg APP_MODULE=api_tabular.tabular.app:app_factory -t "${REGISTRY}/<< pipeline.parameters.docker-image-name-tabular >>:${DOCKER_TAG}" .
-            docker push "${REGISTRY}/<< pipeline.parameters.docker-image-name-tabular >>:${DOCKER_TAG}"
+            docker build --build-arg APP_MODULE=api_tabular.tabular.app:app_factory \
+              -t "<< pipeline.parameters.docker-repo-tabular >>:${DOCKER_TAG_SCM}" \
+              -t "<< pipeline.parameters.docker-repo-tabular >>:${DOCKER_TAG_SHA_SHORT}" \
+              -t "<< pipeline.parameters.docker-repo-tabular >>:${DOCKER_TAG_SHA_LONG}" \
+              -t "<< pipeline.parameters.docker-repo-tabular >>:${DOCKER_TAG_BRANCH}" \
+              ${DOCKER_TAG_GIT:+-t "<< pipeline.parameters.docker-repo-tabular >>:${DOCKER_TAG_GIT}"} \
+              .
+            docker push "<< pipeline.parameters.docker-repo-tabular >>:${DOCKER_TAG_SCM}"
+            docker push "<< pipeline.parameters.docker-repo-tabular >>:${DOCKER_TAG_SHA_SHORT}"
+            docker push "<< pipeline.parameters.docker-repo-tabular >>:${DOCKER_TAG_SHA_LONG}"
+            docker push "<< pipeline.parameters.docker-repo-tabular >>:${DOCKER_TAG_BRANCH}"
+            [ -n "$DOCKER_TAG_GIT" ] && docker push "<< pipeline.parameters.docker-repo-tabular >>:${DOCKER_TAG_GIT}"
             # Metrics API: metrics endpoints only
-            docker build --build-arg APP_MODULE=api_tabular.metrics.app:app_factory -t "${REGISTRY}/<< pipeline.parameters.docker-image-name-metrics >>:${DOCKER_TAG}" .
-            docker push "${REGISTRY}/<< pipeline.parameters.docker-image-name-metrics >>:${DOCKER_TAG}"
+            docker build --build-arg APP_MODULE=api_tabular.metrics.app:app_factory \
+              -t "<< pipeline.parameters.docker-repo-metrics >>:${DOCKER_TAG_SCM}" \
+              -t "<< pipeline.parameters.docker-repo-metrics >>:${DOCKER_TAG_SHA_SHORT}" \
+              -t "<< pipeline.parameters.docker-repo-metrics >>:${DOCKER_TAG_SHA_LONG}" \
+              -t "<< pipeline.parameters.docker-repo-metrics >>:${DOCKER_TAG_BRANCH}" \
+              ${DOCKER_TAG_GIT:+-t "<< pipeline.parameters.docker-repo-metrics >>:${DOCKER_TAG_GIT}"} \
+              .
+            docker push "<< pipeline.parameters.docker-repo-metrics >>:${DOCKER_TAG_SCM}"
+            docker push "<< pipeline.parameters.docker-repo-metrics >>:${DOCKER_TAG_SHA_SHORT}"
+            docker push "<< pipeline.parameters.docker-repo-metrics >>:${DOCKER_TAG_SHA_LONG}"
+            docker push "<< pipeline.parameters.docker-repo-metrics >>:${DOCKER_TAG_BRANCH}"
+            [ -n "$DOCKER_TAG_GIT" ] && docker push "<< pipeline.parameters.docker-repo-metrics >>:${DOCKER_TAG_GIT}"
 
   publish-pypi:
     docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM astral/uv:python3.11-trixie-slim
 
+# Which app to run (e.g. api_tabular.tabular.app:app_factory or api_tabular.metrics.app:app_factory)
+ARG APP_MODULE=api_tabular.tabular.app:app_factory
+
 # install needed apt packages
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends git && \
@@ -15,9 +18,10 @@ ADD . /home/datagouv/
 RUN uv sync --frozen
 RUN chown -R datagouv:datagouv /home/datagouv
 
-# run
+# run (ENV from ARG so shell can expand APP_MODULE at runtime)
 USER datagouv
+ENV APP_MODULE=${APP_MODULE}
 # Use `python -m gunicorn` instead of `gunicorn` due to uv issue #15246: https://github.com/astral-sh/uv/issues/15246
-ENTRYPOINT ["uv", "run", "python", "-m", "gunicorn"]
-# Gunicorn config: 2 workers for ~1 vCPU allocation, aiohttp.GunicornWebWorker for async support, default timeouts suitable for async workers
-CMD ["api_tabular.tabular.app:app_factory", "--bind", "0.0.0.0:8005", "--worker-class", "aiohttp.GunicornWebWorker", "--workers", "2", "--access-logfile", "-"]
+# Shell so APP_MODULE is expanded; bind to 8005 (map to different host ports when running both containers)
+ENTRYPOINT ["/bin/sh", "-c"]
+CMD ["uv run python -m gunicorn $APP_MODULE --bind 0.0.0.0:8005 --worker-class aiohttp.GunicornWebWorker --workers 2 --access-logfile -"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM astral/uv:python3.11-trixie-slim
+
+# install needed apt packages
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends git && \
+    rm -rf /var/lib/apt/lists/*
+
+# create user & group
+RUN groupadd --system datagouv && \
+    useradd --system --gid datagouv --create-home datagouv
+
+# install
+WORKDIR /home/datagouv
+ADD . /home/datagouv/
+RUN uv sync --frozen
+RUN chown -R datagouv:datagouv /home/datagouv
+
+# run
+USER datagouv
+# Use `python -m gunicorn` instead of `gunicorn` due to uv issue #15246: https://github.com/astral-sh/uv/issues/15246
+ENTRYPOINT ["uv", "run", "python", "-m", "gunicorn"]
+# Gunicorn config: 2 workers for ~1 vCPU allocation, aiohttp.GunicornWebWorker for async support, default timeouts suitable for async workers
+CMD ["api_tabular.tabular.app:app_factory", "--bind", "0.0.0.0:8005", "--worker-class", "aiohttp.GunicornWebWorker", "--workers", "2", "--access-logfile", "-"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN groupadd --system datagouv && \
 # install
 WORKDIR /home/datagouv
 ADD . /home/datagouv/
+# setuptools_scm runs git during install; Git refuses a repo whose owner differs from the build user (root).
+RUN git config --global --add safe.directory /home/datagouv
 RUN uv sync --frozen
 RUN chown -R datagouv:datagouv /home/datagouv
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,3 +47,35 @@ services:
       - POSTGRES_PASSWORD=csvapi
     profiles:
       - test
+
+  # Tabular API (run locally via Docker, uses same Dockerfile as CI)
+  tabular-api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        APP_MODULE: api_tabular.tabular.app:app_factory
+    ports:
+      - "8005:8005"
+    environment:
+      - PGREST_ENDPOINT=http://postgrest-test:8080
+    depends_on:
+      - postgrest-test
+    profiles:
+      - test
+
+  # Metrics API (run locally via Docker, uses same Dockerfile as CI)
+  metrics-api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        APP_MODULE: api_tabular.metrics.app:app_factory
+    ports:
+      - "8006:8005"
+    environment:
+      - PGREST_ENDPOINT=http://postgrest-test:8080
+    depends_on:
+      - postgrest-test
+    profiles:
+      - test


### PR DESCRIPTION
Closes #94.

Need the little CI simplification https://github.com/datagouv/api-tabular/pull/97 to be merged first, and the infra workflow to be adapted (it has its own MR).

## Build and push as a Docker image from applicative's CI (here, CircleCI), as we did with cdata

**Changes:**
- Add a production Dockerfile (uv base image, non-root user, gunicorn with aiohttp worker). Same image that was used by the infra, with `APP_MODULE` env var to define if it's for Tabular API or Metrics API
- Refactor CircleCI workflow: single `build` job  that builds the wheel and the Docker image, then pushes the image to the GitLab registry. `publish-pypi` runs only on version tags.
- Workflow: lint, tests, and build run on every push to `main` and on version tags (`v*`). Docker image tag is always the **package version** from setuptools_scm (`RELEASE_VERSION`), so the wheel and the image stay in sync; no separate branch/tag logic for the image.
- CI parameters for registry URL, image name, and build branch (default `main`).

Example workflow:
- **Push a version tag** (e.g. `v1.2.0`):
  - would tag/push image on Docker registry `registry.gitlab.com/etalab/data.gouv.fr/infra/tabular-api:1.2.0` and `registry.gitlab.com/etalab/data.gouv.fr/infra/metrics-api:1.2.0`
  - PyPI: the wheel is published to PyPI as version 1.2.0 (`publish-pypi` runs on version tags).
- **Push on `main`** (no tag):
  - would tag/push image on docker registry `registry.gitlab.com/etalab/data.gouv.fr/infra/tabular-api:1.2.0.dev5` or `...:1.2.0.dev5-a1b2c3d`, and `registry.gitlab.com/etalab/data.gouv.fr/infra/metrics-api:1.2.0.dev5`
  - PyPI: nothing is published: `publish-pypi` runs only on version tags, not on branch pushes.

Each build gets a unique image tag (no overwriting).

## Follow-up

As a follow-up PR, we can also easily set up an automatic infra deployment when pushing a version tag. This would involve a `trigger-gitlab-pipeline job` to send the tag using @jordanguedj ’s scaffolding script
 It’s not a requirement for now, unless you want to go all the way (spoiler: I’m keen, but I’ll keep it for a separate PR).