### PR TITLE
fix(ci): fix push on docker registry when no git tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,9 @@ jobs:
             docker push "<< pipeline.parameters.docker-repo-tabular >>:${DOCKER_TAG_SHA_SHORT}"
             docker push "<< pipeline.parameters.docker-repo-tabular >>:${DOCKER_TAG_SHA_LONG}"
             docker push "<< pipeline.parameters.docker-repo-tabular >>:${DOCKER_TAG_BRANCH}"
-            [ -n "$DOCKER_TAG_GIT" ] && docker push "<< pipeline.parameters.docker-repo-tabular >>:${DOCKER_TAG_GIT}"
+            if [ -n "$DOCKER_TAG_GIT" ]; then
+              docker push "<< pipeline.parameters.docker-repo-tabular >>:${DOCKER_TAG_GIT}"
+            fi
             # Metrics API: metrics endpoints only
             docker build --build-arg APP_MODULE=api_tabular.metrics.app:app_factory \
               -t "<< pipeline.parameters.docker-repo-metrics >>:${DOCKER_TAG_SCM}" \
@@ -145,7 +147,9 @@ jobs:
             docker push "<< pipeline.parameters.docker-repo-metrics >>:${DOCKER_TAG_SHA_SHORT}"
             docker push "<< pipeline.parameters.docker-repo-metrics >>:${DOCKER_TAG_SHA_LONG}"
             docker push "<< pipeline.parameters.docker-repo-metrics >>:${DOCKER_TAG_BRANCH}"
-            [ -n "$DOCKER_TAG_GIT" ] && docker push "<< pipeline.parameters.docker-repo-metrics >>:${DOCKER_TAG_GIT}"
+            if [ -n "$DOCKER_TAG_GIT" ]; then
+              docker push "<< pipeline.parameters.docker-repo-metrics >>:${DOCKER_TAG_GIT}"
+            fi
 
   publish-pypi:
     docker:


### PR DESCRIPTION
We recently [added logic to build the Docker image in the CI and to push it on Docker registry](https://github.com/datagouv/api-tabular/commit/6a3d79dcce0239691d9e185967c4973fab36fd8d) with many tags, to prepare for a future deploy from built images from applicative CI and to normalize our registry policies.
Tags added to Docker image in the CI are:
- long sha
- short sha
- git branch
- release version
- git tag if exists -> but that one was not working when git tag was empty string. This PR just fix that by fixing bash condition syntax on the tag.


