### PR TITLE
fix: patch aiohttp init in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ if "stream_writer" in _signature.parameters:
         kwargs.setdefault("stream_writer", Mock(output_size=0))
         return _orig_init(self, *args, **kwargs)
 
-    ClientResponse.__init__ = _patched_init
+    ClientResponse.__init__ = _patched_init  # type: ignore[assignment]
 
 RESOURCE_ID = "aaaaaaaa-1111-bbbb-2222-cccccccccccc"
 UNKNOWN_RESOURCE_ID = "aaaaaaaa-1111-bbbb-2222-cccccccccccA"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,28 @@
 import csv
+import inspect
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, AsyncGenerator, Generator
+from unittest.mock import Mock
 
 import pytest
 import pytest_asyncio
+from aiohttp import ClientResponse
 from aiohttp.test_utils import TestClient, TestServer
 from aioresponses import aioresponses
+
+# aiohttp 3.14+ requires stream_writer in ClientResponse.__init__,
+# but aioresponses 0.7.x doesn't pass it.
+# See https://github.com/pnuckowski/aioresponses/issues/289
+_signature = inspect.signature(ClientResponse.__init__)
+if "stream_writer" in _signature.parameters:
+    _orig_init = ClientResponse.__init__
+
+    def _patched_init(self, *args, **kwargs):
+        kwargs.setdefault("stream_writer", Mock(output_size=0))
+        return _orig_init(self, *args, **kwargs)
+
+    ClientResponse.__init__ = _patched_init
 
 from api_tabular import config
 from api_tabular.tabular.app import app_factory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,9 @@ from aiohttp import ClientResponse
 from aiohttp.test_utils import TestClient, TestServer
 from aioresponses import aioresponses
 
+from api_tabular import config
+from api_tabular.tabular.app import app_factory
+
 # aiohttp 3.14+ requires stream_writer in ClientResponse.__init__,
 # but aioresponses 0.7.x doesn't pass it.
 # See https://github.com/pnuckowski/aioresponses/issues/289
@@ -23,9 +26,6 @@ if "stream_writer" in _signature.parameters:
         return _orig_init(self, *args, **kwargs)
 
     ClientResponse.__init__ = _patched_init
-
-from api_tabular import config
-from api_tabular.tabular.app import app_factory
 
 RESOURCE_ID = "aaaaaaaa-1111-bbbb-2222-cccccccccccc"
 UNKNOWN_RESOURCE_ID = "aaaaaaaa-1111-bbbb-2222-cccccccccccA"


### PR DESCRIPTION
Fix [CI](https://app.circleci.com/pipelines/github/datagouv/api-tabular/747/workflows/d1baa0d5-bb84-4d4a-a681-cf3d3ac69820/jobs/2465/tests)

aioresponses is not yet compatible with aiohttp 3.14+ (upgraded in https://github.com/datagouv/api-tabular/commit/9533522fb47fefd79ca6f62a812a50ced2ef9c5e).

This is a workaround to make tests pass.

See https://github.com/pnuckowski/aioresponses/issues/289